### PR TITLE
狛吹団員専用のページを新規追加した

### DIFF
--- a/www/common/footer.html
+++ b/www/common/footer.html
@@ -13,7 +13,7 @@
 <div id="bottom">
 <ul>
   <li><a href="/contact">問い合わせ</a></li>
-  <li><a href="http://member.komasui.org/">Member</a></li>
+  <li><a href="/members-only">狛吹団員専用</a></li>
   <li><a href="mailto:?body=http://komasui.org<!--#echo var="REQUEST_URI" -->">友達にメールで送る</a></li>
   <li><a href="/link/">リンク</a></li>
 </ul>

--- a/www/feed/index.xml
+++ b/www/feed/index.xml
@@ -11,6 +11,8 @@
 		<description>東京都狛江市で活動している吹奏楽団の更新情報です。</description>
 		<items>
 			<rdf:Seq>
+				<rdf:li rdf:resource="http://komasui.org/members-only" />
+				<rdf:li rdf:resource="http://komasui.org/schedule" />
 				<rdf:li rdf:resource="http://komasui.org/concert/20141223" />
 				<rdf:li rdf:resource="http://komasui.org/schedule" />
 				<rdf:li rdf:resource="http://komasui.org/recruit" />
@@ -91,6 +93,18 @@
 			</rdf:Seq>
 		</items>
 	</channel>
+	<item rdf:about="http://komasui.org/members-only">
+		<link>http://komasui.org/members-only</link>
+		<title>狛吹団員専用</title>
+		<description>狛吹団員専用を更新しました！</description>
+		<dc:date>2014-10-05T00:00:00+09:00</dc:date>
+	</item>
+	<item rdf:about="http://komasui.org/schedule">
+		<link>http://komasui.org/schedule</link>
+		<title>練習予定</title>
+		<description>練習予定を更新しました！</description>
+		<dc:date>2014-09-01T00:00:00+09:00</dc:date>
+	</item>
 	<item rdf:about="http://komasui.org/concert/20141223">
 		<link>http://komasui.org/concert/20141223</link>
 		<title>第15回定期演奏会</title>

--- a/www/index.html
+++ b/www/index.html
@@ -49,6 +49,7 @@
 
 <div class="news">
 <ul>
+  <li>2014/10/05 <a href="/members-only">狛吹団員専用</a>を更新しました。</li>
   <li>2014/09/01 <a href="/schedule">練習予定</a>を更新しました。</li>
   <li>2014/08/18 <a href="/concert/20141223">第15回定期演奏会</a>を更新しました。</li>
   <li>2014/04/05 <a href="/recruit">団員募集</a>を更新しました。</li>

--- a/www/members-only.html
+++ b/www/members-only.html
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="ja" xml:lang="ja">
+
+<head>
+<!--#include virtual="/common/head.html" -->
+  <title>狛吹団員専用 - 狛江市民吹奏楽団</title>
+  <meta property="og:title" content="狛吹団員専用" />
+  <meta name="description" content="東京都狛江市で活動している吹奏楽団。毎週土曜夜の合奏練習を中心に狛江市で活動しています。" />
+  <meta name="keywords" content="狛江市民吹奏楽団, 狛吹" />
+</head>
+
+<body>
+<div id="wrap">
+<!-- header_start -->
+<div id="top">
+<h1>狛吹団員専用 - 狛江市民吹奏楽団</h1>
+</div>
+<!--#include virtual="/common/menu.html" -->
+<!-- header_end -->
+
+<!-- contents_start -->
+<div id="contents">
+
+<h2>狛吹団員<span>専</span>用</h2>
+
+<div id="members-only">
+
+<p>※この先は狛吹の団員向けの情報です</p>
+
+<h3>団員専用情報</h3>
+
+<p>狛吹では情報共有の円滑化を図るため<a href="http://go.komasui.org/apps">Google Apps</a>というサービスを利用しています。</p>
+<p>狛吹団員で<strong>狛吹アカウント</strong>を失念された場合は<a href="mailto:webmaster@komasui.org">狛吹管理者</a>にご連絡をお願いします。</p>
+
+<h4>カレンダー、メーリングリスト、ドキュメント、他</h4>
+<ul>
+  <li><a href="http://go.komasui.org/about-komasui-mailing-list">狛吹MLの御案内</a></li>
+  <li><a href="http://go.komasui.org/gcal">狛吹カレンダー</a> ※一般開示もされています</li>
+  <li><a href="http://go.komasui.org/drive">狛吹ドキュメント</a></li>
+</ul>
+
+<h4>スマホでも！</h4>
+<ul>
+  <li><a href="http://go.komasui.org/how-to-set-komasui-calendar-for-iphone">iPhoneに狛吹カレンダーを設定する方法</a></li>
+</ul>
+
+<h4>携帯でも！</h4>
+<ul>
+  <li><a href="http://go.komasui.org/gcmg">狛吹カレンダー（携帯）</a> ※一般開示もされています</li>
+  <li><a href="http://www.google.com/intl/ja_ALL/mobile/google-mobile-app/">携帯電話で Google Mobile App</a></li>
+</ul>
+
+<h3>一般開示情報</h3>
+
+<p>団員以外にも閲覧可能な情報です。</p>
+
+<h4>規約</h4>
+<ul>
+  <li><a href="http://go.komasui.org/kiyaku">狛江市民吹奏楽団規約</a> (<a href="http://go.komasui.org/kiyaku_pdf">PDF</a>) </li>
+</ul>
+
+<h4>練習計画</h4>
+<ul>
+  <li><a href="http://go.komasui.org/gcal">狛吹カレンダー</a></li>
+</ul>
+
+<h4>twitter</h4>
+<ul>
+  <li><a href="http://twitter.com/komasui">@komasui</a></li>
+</ul>
+
+<h4>Facebook</h4>
+<ul>
+  <li><a href="https://www.facebook.com/komasui">[Facebookページ] 狛江市民吹奏楽団</a></li>
+</ul>
+
+<h4>twitter</h4>
+<ul>
+  <li><a href="https://plus.google.com/112940233546049057646/">[Google+ページ] 狛江市民吹奏楽団</a></li>
+</ul>
+
+<h4>mixi</h4>
+<ul>
+  <li><a href="http://go.komasui.org/mixi_page">mixiページ</a></li>
+  <li><a href="http://go.komasui.org/mixi_community">mixiコミュニティ</a></li>
+  <li><a href="http://go.komasui.org/mixi_appli">mixiアプリ</a></li>
+</ul>
+
+<h4>Github</h4>
+<ul>
+  <li><a href="https://github.com/komasui/komasui.org">https://github.com/komasui/komasui.org</a></li>
+</ul>
+
+</div>
+<!-- contents_end -->
+
+<!-- footer_start -->
+<!--#include virtual="/common/footer.html" -->
+<!-- footer_end -->
+</div>
+</body>
+</html>


### PR DESCRIPTION
団員専用サイト関連への入口用にサブドメインを切っていたが、管理のため同ドメインに一本化することとした。また古い記載が多くあったため記載内容を全面的に見なおした。ついでにfeedを更新しておいた。
